### PR TITLE
Embed the Twitter feed on the homepage of the site

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,9 @@ languageCode = "en-us"
 title = "My New Hugo Site"
 theme = "bsb2020"
 
+[params]
+    twitterfeed = "https://twitter.com/BSidesBoulder?ref_src=twsrc%5Etfw"
+
 [menu]
 [[menu.main]]
     identifier = "callforpapers"

--- a/content/pages/home.md
+++ b/content/pages/home.md
@@ -52,4 +52,4 @@ your help.  Check out [Volunteer Page](/volunteers/)
 
 {{< news >}}
 
-{{< twitter twitterfeed="https://twitter.com/BSidesBoulder?ref_src=twsrc%5Etfw" >}}
+{{< twitter >}}

--- a/content/pages/home.md
+++ b/content/pages/home.md
@@ -13,8 +13,6 @@ We are pleased to announce that BSides is officially coming to Boulder, Co. We
 have secured a location (courtesy of CU Boulder), are we are looking forward to 
 putting on a great event.
 
-{{< news >}}
-
 ## Welcome
 
 We are in the process of getting the initial foundations in place to bring
@@ -51,3 +49,7 @@ BSides Boulder will be happening Saturday, April 18, 2020.
 
 If you are interested in helping out to make this become a reality... we need
 your help.  Check out [Volunteer Page](/volunteers/)
+
+{{< news >}}
+
+{{< twitter twitterfeed="https://twitter.com/BSidesBoulder?ref_src=twsrc%5Etfw" >}}

--- a/themes/bsb2020/layouts/shortcodes/twitter.html
+++ b/themes/bsb2020/layouts/shortcodes/twitter.html
@@ -1,10 +1,6 @@
 <div class="twitter-wrapper">
   <a
-  {{ if .IsNamedParams }}
-    href="{{ .Get "twitterfeed" }}"
-  {{ else }}
-    href="{{ .Get 0 }}"
-  {{ end }}
+    href="{{ .Site.Params.twitterfeed }}"
     class="twitter-timeline"
     data-height="800">
 

--- a/themes/bsb2020/layouts/shortcodes/twitter.html
+++ b/themes/bsb2020/layouts/shortcodes/twitter.html
@@ -1,0 +1,15 @@
+<div class="twitter-wrapper">
+  <a
+  {{ if .IsNamedParams }}
+    href="{{ .Get "twitterfeed" }}"
+  {{ else }}
+    href="{{ .Get 0 }}"
+  {{ end }}
+    class="twitter-timeline"
+    data-height="800">
+
+    Tweets by BSidesBoulder
+
+  </a>
+</div>
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/themes/bsb2020/static/css/site.css
+++ b/themes/bsb2020/static/css/site.css
@@ -124,6 +124,11 @@ footer {
     margin-bottom: 40px;
 } 
 
+.twitter-wrapper {
+    width: 50%;
+    border: 1px solid black;
+}
+
 li.nav-social {
     list-style-type: none;
     float: left;


### PR DESCRIPTION
Fix for #19. The new page is styled a little differently, with the Twitter feed and news feed at the bottom of the page (picture below), which I felt didn't squash the page text as much. If you prefer, I can modify the style from what's shown.

![Screenshot from 2019-12-14 17-47-11](https://user-images.githubusercontent.com/17100608/70856451-a88f9380-1e9a-11ea-9033-b4d8a0cbfff1.png)
