### PR TITLE
Remove the speaker-card CSS class.

### DIFF
--- a/themes/bsb2020v2/layouts/shortcodes/speakers.html
+++ b/themes/bsb2020v2/layouts/shortcodes/speakers.html
@@ -2,7 +2,7 @@
     {{ range $.Site.Data.speakers }}
         {{if eq .speaker.keynote_speaker false}}
             <a name="{{urlize .speaker.first_name}}-{{ urlize .speaker.last_name}}"></a>
-            <div class="uk-card uk-card-default uk-grid-collapse uk-child-width-1-2@s uk-margin speaker-card" uk-grid>
+            <div class="uk-card uk-card-default uk-grid-collapse uk-child-width-1-2@s uk-margin" uk-grid>
                 <div class="uk-card-media-left uk-cover-container">
                     <img src="/img/speaker/unoptimized/{{ .speaker.photo }}" alt="" uk-cover>
                     <canvas width="600" height="400"></canvas>

--- a/themes/bsb2020v2/static/css/bsides2020v2.css
+++ b/themes/bsb2020v2/static/css/bsides2020v2.css
@@ -122,10 +122,6 @@ h1 {
     font-size: 2em;
 }
 
-.speaker-card {
-    height: 600px;
-}
-
 .cover-image {
     background-image: url('/img/cover.png');
     background-size: auto 100%;


### PR DESCRIPTION
Modifies the styling of the speaker cards (for non-keynotes) on the
/speakers page. Previously these cards had an enforced height of 600px,
which caused issues (especially on mobile) where text would overflow the
card and go into the next card on the page.

Fixes #58.