### PR TITLE
Fix Amie's and Erika's speaker cards.

### DIFF
--- a/data/speakers/noerenburg_erika.yaml
+++ b/data/speakers/noerenburg_erika.yaml
@@ -4,7 +4,7 @@ speaker:
   title: ""
   company: ""
   twitter: gutterchurl
-  bio: " Erika Noerenberg is currently surviving 2020, honing such survival skills as home haircuts and mask sewing. Most recently a Senior Threat Researcher with VMware Carbon Black’s Threat Analysis Unit, Erika has over 15 years of experience in the security industry specializing in digital forensics, malware analysis, and software development.
+  bio: " Erika Noerenberg is currently surviving 2020, honing such survival skills as home haircuts and mask sewing. Most recently a Senior Threat Researcher with VMware Carbon Black's Threat Analysis Unit, Erika has over 15 years of experience in the security industry specializing in digital forensics, malware analysis, and software development.
 
 Previously, she worked as a malware analyst at LogRhythm Labs and as a forensic analyst and reverse engineer for the Defense Cyber Crime Center (DC3), performing system and malware examinations in support of intrusions investigations for the Department of Defense and FBI."
   session_title: "Pentesting the self: Hacking Failure for Success"

--- a/data/speakers/stepanovich_amie.yaml
+++ b/data/speakers/stepanovich_amie.yaml
@@ -3,12 +3,12 @@ speaker:
   last_name: Stepanovich
   title: Executive Director
   company: Silicon Flatirons
-  twitter: ""
+  twitter: "astepanovich"
   bio: "Amie Stepanovich is the Executive Director at Silicon Flatirons. She is a nationally recognized expert in domestic surveillance, cybersecurity, and privacy law.
 
 Stepanovich previously served as U.S. Policy Manager and Global Policy Counsel at Access Now in Washington, D.C., where she worked to protect human rights through law and policy involving technologies and their use. Prior to that, she was the Director of the Domestic Surveillance Project at the Electronic Privacy Information Center. She has testified in both the U.S. Senate and the House of Representatives, and before the German and Australian Parliaments.
 
-She serves as a board member to the Internet Education Foundation and as an advisory board member to the Future of Privacy Forum. In 2014, Stepanovich was named in Forbes Magazine’s 30 Under 30 Leaders in Law and Policy."
+She serves as a board member to the Internet Education Foundation and as an advisory board member to the Future of Privacy Forum. In 2014, Stepanovich was named in Forbes Magazine's 30 Under 30 Leaders in Law and Policy."
   session_title: "Encryption Policy, from past to present and what lies ahead"
   photo: stepanovich_amie.jpg
   keynote_speaker: False


### PR DESCRIPTION
Amie's card on the /speakers page has a couple of issues that are fixed
by this commit:
- A Unicode apostrophe that Hugo doesn't like and doesn't render
  correctly on the page. This has been replaced by an ASCII apostrophe.
- Amie's Twitter is missing (this is now corrected).