### PR TITLE
Fix links from /speakers to /sessions.

### DIFF
--- a/data/speakers/mckee_james.yaml
+++ b/data/speakers/mckee_james.yaml
@@ -5,6 +5,6 @@ speaker:
   company: Trimble
   twitter: punkcoder
   bio: "James is a developer and security advocate whose biggest responsibility is leading developer security practices. He sets the standards and procedures for how the practice operates, and leads all client engagement efforts with regard to security. He also takes the lead in making sure that company staff (developers specifically) are properly trained and following best practices with regard to application security.  In a past life James was responsible for Architecting and developing solutions on multi-million implementation efforts. Key clients included the Eight Fortune 500 companies (Seven in the Fortune 100), as well as several well known non-profits and leaders in their industries. Vertices served included healthcare, transportation, financial services, retail, insurance, and energy."
-  session_title: "Begining Pentesting Android Application"
+  session_title: "Beginning Pentesting Android Application"
   photo: mckee_james.jpg
   keynote_speaker: False

--- a/data/speakers/pearce_bo.yaml
+++ b/data/speakers/pearce_bo.yaml
@@ -6,6 +6,6 @@ speaker:
   twitter: ""
   bio: |
     From Colorado and was a Computer Science student at CU. Currently working as a Senior Consultant at a Boulder security company.
-  session_title: "Getting into Writing Windows 1-days with BlueKeep"
+  session_title: "Writing Windows N-Days"
   photo: unknown.jpg
   keynote_speaker: False


### PR DESCRIPTION
Fix links to talks for the following speakers:
- James McKee
- Bo Pearce

These links were previously broken due to changes in the talk titles for
the speakers (see fbc5b3a1 and b94701ba).

Closes #65.