### PR TITLE
Change the default Discord invite link

### DIFF
--- a/content/pages/home.md
+++ b/content/pages/home.md
@@ -13,7 +13,7 @@ url: "/home/"
 
 ## Latest updates
 
-**10/5/2020**: Our Discord server is live! Join at https://discord.gg/tn4pukS
+**10/5/2020**: Our Discord server is live! Join at https://discord.gg/Fn6XJkD
 
 ## BSides is coming to Boulder!
 

--- a/themes/bsb2020v2/layouts/partials/navbar.html
+++ b/themes/bsb2020v2/layouts/partials/navbar.html
@@ -18,7 +18,7 @@
         <ul class="uk-navbar-nav">
             <!-- <li class="nav-social"><a href="https://www.facebook.com/groups/511752762995313/" target="_blank"><i class="fab fa-facebook"></i></a></li> -->
             <li class="nav-social"><a href="https://www.youtube.com/channel/UCRUmseZMk79gcQdNga3DEHQ" target="_blank"><i class="fab fa-youtube"></i></a></li>
-            <li class="nav-social"><a href="https://discord.gg/tn4pukS" target="_blank"><i class="fab fa-discord"></i></a></li>
+            <li class="nav-social"><a href="https://discord.gg/Fn6XJkD" target="_blank"><i class="fab fa-discord"></i></a></li>
             <li class="nav-social"><a href="https://twitter.com/bsidesboulder" target="_blank"><i class="fab fa-twitter"></i></a></li>
             <li class="nav-social"><a href="https://boulderinfosec.slack.com" target="_blank"><i class="fab fa-slack"></i></a></li>
             <a class="uk-navbar-toggle" uk-toggle="target: #sidenav"uk-navbar-toggle-icon></a>        


### PR DESCRIPTION
Change the default Discord invite link on the site to point to the #welcome channel rather than #general.